### PR TITLE
Downgrade Android minSdkVersion to 23

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -47,7 +47,7 @@ android {
     }
 
     defaultConfig {
-        minSdkVersion 26
+        minSdkVersion 23
     }
 
     dependencies {


### PR DESCRIPTION
Downgrade Android minSdkVersion to 23 to allow better device targeting.

This handles this request https://github.com/ChunkyTofuStudios/native_geofence/issues/23