### PR TITLE
fix(ios): Register main NativeGeofenceApi in background Flutter engine  #26 

### DIFF
--- a/ios/Classes/delegates/LocationManagerDelegate.swift
+++ b/ios/Classes/delegates/LocationManagerDelegate.swift
@@ -97,7 +97,12 @@ class LocationManagerDelegate: NSObject, CLLocationManagerDelegate {
         nativeGeofenceBackgroundApi = NativeGeofenceBackgroundApiImpl(binaryMessenger: headlessFlutterEngine!.binaryMessenger)
         NativeGeofenceBackgroundApiSetup.setUp(binaryMessenger: headlessFlutterEngine!.binaryMessenger, api: nativeGeofenceBackgroundApi)
         log.debug("NativeGeofenceBackgroundApi initialized.")
-        
+
+        // Also register the main NativeGeofenceApi in background context
+        let nativeGeofenceMainApi = NativeGeofenceApiImpl(registerPlugins: flutterPluginRegistrantCallback!)
+        NativeGeofenceApiSetup.setUp(binaryMessenger: headlessFlutterEngine!.binaryMessenger, api: nativeGeofenceMainApi)
+        log.debug("NativeGeofenceMainApi also initialized in background context.")
+
         return nativeGeofenceBackgroundApi
     }
 }


### PR DESCRIPTION
- iOS background callbacks previously only had access to NativeGeofenceBackgroundApi
- This caused "channel not found" errors when calling removeAllGeofences() from geofence callbacks
- Now registers both background AND main APIs in the headless Flutter engine
- Enables all main API methods (removeAllGeofences, createGeofence, etc.) to work in background context
- Fixes issue where geofence management from callbacks was impossible on iOS
#26 