### PR TITLE
Prevent unexpected events to trigger on iOS

### DIFF
--- a/ios/Classes/delegates/LocationManagerDelegate.swift
+++ b/ios/Classes/delegates/LocationManagerDelegate.swift
@@ -42,6 +42,10 @@ class LocationManagerDelegate: NSObject, CLLocationManagerDelegate {
             log.error("Unknown CLRegion type: \(String(describing: type(of: region)))")
             return
         }
+
+        if !activeGeofence.triggers.contains(event) {
+            return
+        }
         
         guard let callbackHandle = NativeGeofencePersistence.getRegionCallbackHandle(id: activeGeofence.id) else {
             log.error("Callback handle for region \(activeGeofence.id) not found.")


### PR DESCRIPTION
After upgrading my app to Flutter 3.35 the plugin started to misbehave for me. I'm not entirely sure if it is the Flutter upgrade or iOS 26, but currently on a physical iOS device geofence callbacks are always triggered after adding a region (when `While in use` location permission is granted at least). I define all my geofences with `initialTrigger: false` and `triggers: {GeofenceEvent.enter}`, but a `.outside` event is triggered for all registered regions.

I placed some breakpoints in XCode and I could confirm that the `CLCircularRegion`s `notifyOnExit` property is `false` before registering it, so I don't understand why iOS trigger an outside event right after calling `startMonitoring` on that region. It does not run into the `requestState` branch either.

My fix just checks if the previously registered geofence contains the triggered event and don't do anything if not. This is more like a workaround, than a fix.

While investigating I saw that `startMonitoring` is deprecated and a new [CLMonitor](https://developer.apple.com/documentation/corelocation/clmonitor-2r51v) solution should be used instead of that (from iOS 17). After experimenting a lot with that, I couldn't find out how would that work with Flutter. That would need a totally different architecture, so I don't know if that would work better.