### PR TITLE
Support AGP 9 built-in Kotlin (keep AGP 8 compatibility)

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,11 +29,14 @@ Battery efficient Flutter geofencing plugin that uses native iOS and Android API
 
 ### Android
 
-1. Upgrade to Kotlin `1.9.25` or later
+1. Kotlin setup
 
-Follow the guide [here](https://docs.flutter.dev/release/breaking-changes/kotlin-version) to ensure your Kotlin version is at least `1.9.25`.
+This plugin works with both Android Kotlin setups, so follow the one that matches your toolchain:
 
-The latest Kotlin version can be found [here](https://mvnrepository.com/artifact/org.jetbrains.kotlin.android/org.jetbrains.kotlin.android.gradle.plugin). Note that as of Jan 2025 Flutter does not work well with Kotlin 2+.
+- **Flutter 3.44+ (AGP 9) — built-in Kotlin:** Kotlin is provided by the Android Gradle Plugin, so there is nothing to add. Do **not** apply the `kotlin-android` Gradle plugin yourself — AGP 9 rejects an explicitly applied Kotlin plugin. See Flutter's [built-in Kotlin migration guide](https://docs.flutter.dev/release/breaking-changes/migrate-to-built-in-kotlin).
+- **Older Flutter (AGP 8):** apply the Kotlin Gradle plugin as usual, and ensure your Kotlin version is at least `1.9.25` (see this [guide](https://docs.flutter.dev/release/breaking-changes/kotlin-version)). The latest Kotlin version can be found [here](https://mvnrepository.com/artifact/org.jetbrains.kotlin.android/org.jetbrains.kotlin.android.gradle.plugin).
+
+The [example app](https://github.com/ChunkyTofuStudios/native_geofence/tree/main/example/android) demonstrates the AGP 8 setup, with comments in its Gradle files noting the AGP 9 difference.
 
 NOTE: You may also need Gradle 8+ to use this plugin. See this [issue](https://github.com/ChunkyTofuStudios/native_geofence/issues/4).
 

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -24,21 +24,26 @@ allprojects {
 }
 
 apply plugin: 'com.android.library'
-apply plugin: 'kotlin-android'
+
+// AGP 9 enables built-in Kotlin and rejects an explicitly applied Kotlin Gradle
+// plugin. On older AGP (Flutter < 3.44) we still have to apply it ourselves, so
+// only apply `kotlin-android` when built-in Kotlin isn't available. This keeps
+// the plugin building on both pre- and post-3.44 Flutter.
+// https://docs.flutter.dev/release/breaking-changes/migrate-to-built-in-kotlin/for-plugin-authors
+def agpMajorVersion = com.android.Version.ANDROID_GRADLE_PLUGIN_VERSION.tokenize('.')[0] as int
+if (agpMajorVersion < 9) {
+    apply plugin: 'kotlin-android'
+}
 apply plugin: 'kotlinx-serialization'
 
 android {
     namespace 'com.chunkytofustudios.native_geofence'
 
-    compileSdk 34
+    compileSdk 35
 
     compileOptions {
         sourceCompatibility = JavaVersion.VERSION_17
         targetCompatibility = JavaVersion.VERSION_17
-    }
-
-    kotlinOptions {
-        jvmTarget = "17"
     }
 
     sourceSets {
@@ -65,6 +70,14 @@ android {
                showStandardStreams = true
             }
         }
+    }
+}
+
+// Works under both built-in Kotlin (AGP 9) and the explicitly applied
+// kotlin-android plugin (older AGP); replaces the legacy `kotlinOptions` block.
+kotlin {
+    compilerOptions {
+        jvmTarget = org.jetbrains.kotlin.gradle.dsl.JvmTarget.JVM_17
     }
 }
 

--- a/example/android/app/build.gradle
+++ b/example/android/app/build.gradle
@@ -1,5 +1,10 @@
 plugins {
     id("com.android.application")
+    // This example targets AGP 8 for broad compatibility, so it applies the
+    // Kotlin Gradle plugin explicitly. On Flutter 3.44+ / AGP 9 Kotlin is built
+    // in — omit this line, as AGP 9 rejects an explicitly applied kotlin-android.
+    // native_geofence supports both setups. See:
+    // https://docs.flutter.dev/release/breaking-changes/migrate-to-built-in-kotlin
     id("kotlin-android")
     id("dev.flutter.flutter-gradle-plugin")
 }

--- a/example/android/settings.gradle
+++ b/example/android/settings.gradle
@@ -20,6 +20,8 @@ pluginManagement {
 plugins {
     id "dev.flutter.flutter-plugin-loader" version "1.0.0"
     id "com.android.application" version "8.6.1" apply false
+    // Targets AGP 8 for broad compatibility. On Flutter 3.44+ / AGP 9, Kotlin is
+    // built in and this Kotlin Gradle plugin declaration isn't needed.
     id "org.jetbrains.kotlin.android" version "2.2.0" apply false
 }
 


### PR DESCRIPTION
## What this does
Makes the plugin build under AGP 9 / built-in Kotlin (Flutter 3.44+) while staying compatible with older Flutter (AGP 8). Closes #50.

## Changes
-- Applid the kotlin-android Gradle plugin only when AGP < 9. On AGP 9 the built-in Kotlin support provides it, and applying it explicitly breaks the build.
-- Replaced the legacy `kotlinOptions` block with the top-level `kotlin { compilerOptions { ... } }` DSL, which works under both paths.
-- Bumped compileSdk 34 -> 35. The existing androidx.work dependency already requires consumers to compile against API 35.  AGP 8 tolerated the mismatch but AGP 9 enforces it. minSdk (23) and targetSdk are unchanged.
-- Documented both setups in the README and the example app's Gradle files so new (Flutter 3.44+) users aren't confused by the AGP 8 example.  This better illustrates the two different toolchain route.

## Why compileSdk 34 -> 35
This isn't a new requirement: the existing `androidx.work:work-runtime` dependency already requires consumers to compile against API 35, and that propagates to apps using this plugin. The plugin pinned `compileSdk 34`, which AGP 8 tolerated but AGP 9 enforces.  This only changes the compile-time API level — `minSdk` (23) and `targetSdk` are unchanged, so no devices or runtime behavior are affected.

## Backward compatibility
I kept this very intentionally...the minimum Flutter version is unchanged (no pubspec floor bump), and older Flutter / AGP 8 still builds via the conditional. In theory, if we followed the "true Flutter path" you could make this a breaking change and take out the if blocks...but I didn't think that was necessary.  If you'd rather drop pre-3.44 support and take the simpler unconditional migration, let me know and I'll make the change.  But I tried to think "don't break people" first.

## Dependency audit (you asked me to check)
- Most are already current: mockito-core (5.18.0), kotlinx-serialization-json (1.9.0), guava (33.4.8-android), play-services-location (21.3.0).
- There are some minor updates available, left out to keep this PR focused: androidx.work 2.10.2 -> 2.11.2, androidx.concurrent 1.2.0 -> 1.3.0. Both are fine to take with compileSdk 35 — I can include those if you want, but I thought you might want a separate spec bump ticket/PR for that.
- Major updates available: play-services-maps 19.2.0 -> 20.0.0.  That's completely your call but it was unnecessary for this PR and I'm leery of major versions (especially .0's) anyway.

## Testing
- AGP 8 (Flutter 3.38 via fvm): example builds; `kotlin-android` is applied.
- AGP 9 / built-in Kotlin (Flutter 3.44): example builds; `kotlin-android` not applied;
  `kotlinx-serialization` compiles cleanly under built-in Kotlin.