### PR TITLE
Fix Android build when built-in Kotlin is disabled on AGP 9

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -26,12 +26,17 @@ allprojects {
 apply plugin: 'com.android.library'
 
 // AGP 9 enables built-in Kotlin and rejects an explicitly applied Kotlin Gradle
-// plugin. On older AGP (Flutter < 3.44) we still have to apply it ourselves, so
-// only apply `kotlin-android` when built-in Kotlin isn't available. This keeps
-// the plugin building on both pre- and post-3.44 Flutter.
+// plugin, so we must apply `kotlin-android` ourselves only when built-in Kotlin
+// is NOT active. That is the case on older AGP (Flutter < 3.44), but also on
+// AGP 9 when `android.builtInKotlin` is disabled — which Flutter's template does
+// by default while other plugins migrate. Checking the AGP version alone is not
+// enough; we must also honor the flag, or the `kotlin {}` block below has no
+// Kotlin extension to configure.
 // https://docs.flutter.dev/release/breaking-changes/migrate-to-built-in-kotlin/for-plugin-authors
 def agpMajorVersion = com.android.Version.ANDROID_GRADLE_PLUGIN_VERSION.tokenize('.')[0] as int
-if (agpMajorVersion < 9) {
+def builtInKotlinFlag = project.findProperty('android.builtInKotlin')
+def builtInKotlinActive = agpMajorVersion >= 9 && (builtInKotlinFlag == null || builtInKotlinFlag.toString().toBoolean())
+if (!builtInKotlinActive) {
     apply plugin: 'kotlin-android'
 }
 apply plugin: 'kotlinx-serialization'

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -32,10 +32,15 @@ apply plugin: 'com.android.library'
 // by default while other plugins migrate. Checking the AGP version alone is not
 // enough; we must also honor the flag, or the `kotlin {}` block below has no
 // Kotlin extension to configure.
+//
+// Built-in Kotlin is active on AGP 9+ unless explicitly disabled. We compare
+// against the literal "false" (null-safe, trimmed, case-insensitive) rather than
+// parsing a boolean, so an unexpected value can never throw — it simply leaves
+// built-in Kotlin treated as active, which is AGP 9's own default.
 // https://docs.flutter.dev/release/breaking-changes/migrate-to-built-in-kotlin/for-plugin-authors
 def agpMajorVersion = com.android.Version.ANDROID_GRADLE_PLUGIN_VERSION.tokenize('.')[0] as int
-def builtInKotlinFlag = project.findProperty('android.builtInKotlin')
-def builtInKotlinActive = agpMajorVersion >= 9 && (builtInKotlinFlag == null || builtInKotlinFlag.toString().toBoolean())
+def builtInKotlinFlag = project.findProperty('android.builtInKotlin')?.toString()?.trim()?.toLowerCase()
+def builtInKotlinActive = agpMajorVersion >= 9 && builtInKotlinFlag != 'false'
 if (!builtInKotlinActive) {
     apply plugin: 'kotlin-android'
 }


### PR DESCRIPTION
## What this fixes
native_geofence 1.3.0 fails to build on AGP 9 when `android.builtInKotlin=false`:

    Could not find method kotlin() ... android/build.gradle line: 78

That flag is Flutter's template default on AGP 9 (built-in Kotlin is held off while other plugins migrate), and a fresh `flutter create` app on Flutter 3.44 ships with it set to false — so stock 1.3.0 fails to build new apps out of the box, and any AGP 9 app that still uses a plugin applying the Kotlin Gradle plugin.

Follow-up to the built-in Kotlin migration (PR #52) and provides a better fix for ticket #50.

## Cause
I failed to test the "whole matrix" of AGP major version and android.builtInKotlin combinations.  The 1.3.0 conditional keys only on the AGP major version:

    if (agpMajorVersion < 9) { apply plugin: 'kotlin-android' }

On AGP 9 it skips kotlin-android, assuming built-in Kotlin will provide Kotlin. But with `android.builtInKotlin=false`, AGP 9 does not — so the top-level `kotlin {}` block has no Kotlin extension to configure, and the build fails.

## Fix
We need to honor the `android.builtInKotlin` flag irrespective of major version of AGP. Apply kotlin-android whenever built-in Kotlin is not active: AGP < 9, or AGP 9 with the flag disabled. (AGP < 9 ignores the flag entirely, since built-in Kotlin is an AGP 9 feature.)

## Testing
This time I spun up a few apps and overrode the dependencies to my local branch of this project.  Every "whole matrix" combination builds:

  AGP 8.6.1 + builtInKotlin=false  -> applies kotlin-android   (flag ignored pre-AGP 9)
  AGP 8.6.1 + builtInKotlin=true   -> applies kotlin-android   (flag ignored pre-AGP 9)
  AGP 9.0.1 + builtInKotlin=true   -> skips kotlin-android
  AGP 9.0.1 + builtInKotlin=false  -> applies kotlin-android   (the case that broke 1.3.0)

AGP 9 with the flag unset is also covered (treated as built-in-on, matching AGP's default). Combo 3 is a positive proof rather than luck: AGP 9 hard-fails if kotlin-android is applied while built-in Kotlin is active, so a green build there means the plugin correctly skipped it.